### PR TITLE
Introduce the DeployKey actor type for repository rulesets

### DIFF
--- a/github/resource_github_repository_ruleset.go
+++ b/github/resource_github_repository_ruleset.go
@@ -540,7 +540,7 @@ func resourceGithubRepositoryRulesetUpdate(d *schema.ResourceData, meta interfac
 
 	ctx := context.WithValue(context.Background(), ctxId, rulesetID)
 
-	ruleset, _, err := client.Repositories.UpdateRuleset(ctx, owner, repoName, rulesetID, rulesetReq)
+	ruleset, _, err := client.Repositories.UpdateRulesetNoBypassActor(ctx, owner, repoName, rulesetID, rulesetReq)
 	if err != nil {
 		return err
 	}

--- a/github/resource_github_repository_ruleset.go
+++ b/github/resource_github_repository_ruleset.go
@@ -57,18 +57,19 @@ func resourceGithubRepositoryRuleset() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"actor_id": {
 							Type:        schema.TypeInt,
-							Required:    true,
+							Optional:    true,
+							Default:     nil,
 							Description: "The ID of the actor that can bypass a ruleset. When `actor_type` is `OrganizationAdmin`, this should be set to `1`.",
 						},
 						"actor_type": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringInSlice([]string{"RepositoryRole", "Team", "Integration", "OrganizationAdmin"}, false),
-							Description:  "The type of actor that can bypass a ruleset. Can be one of: `RepositoryRole`, `Team`, `Integration`, `OrganizationAdmin`.",
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The type of actor that can bypass a ruleset. Can be one of: `RepositoryRole`, `Team`, `Integration`, `OrganizationAdmin`.",
 						},
 						"bypass_mode": {
 							Type:         schema.TypeString,
-							Required:     true,
+							Optional:     true,
+							Default:      "always",
 							ValidateFunc: validation.StringInSlice([]string{"always", "pull_request"}, false),
 							Description:  "When the specified actor can bypass the ruleset. pull_request means that an actor can only bypass rules on pull requests. Can be one of: `always`, `pull_request`.",
 						},

--- a/github/respository_rules_utils.go
+++ b/github/respository_rules_utils.go
@@ -44,7 +44,11 @@ func expandBypassActors(input []interface{}) []*github.BypassActor {
 		inputMap := v.(map[string]interface{})
 		actor := &github.BypassActor{}
 		if v, ok := inputMap["actor_id"].(int); ok {
-			actor.ActorID = github.Int64(int64(v))
+			if v == 0 {
+				actor.ActorID = nil
+			} else {
+				actor.ActorID = github.Int64(int64(v))
+			}
 		}
 
 		if v, ok := inputMap["actor_type"].(string); ok {

--- a/github/respository_rules_utils.go
+++ b/github/respository_rules_utils.go
@@ -35,9 +35,6 @@ func resourceGithubRulesetObject(d *schema.ResourceData, org string) *github.Rul
 }
 
 func expandBypassActors(input []interface{}) []*github.BypassActor {
-	if len(input) == 0 {
-		return nil
-	}
 	bypassActors := make([]*github.BypassActor, 0)
 
 	for _, v := range input {


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves https://github.com/integrations/terraform-provider-github/issues/2254

Closes https://github.com/integrations/terraform-provider-github/pull/2255 . This is a replacement.

API docs: https://docs.github.com/en/rest/repos/rules?apiVersion=2022-11-28#update-a-repository-ruleset

Related:
- https://github.com/WATonomous/infra-config/issues/3430
----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

`DeployKey` is not a valid actor_type for github_repository_ruleset->bypass_actors.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Any string is a valid actor_type. Validation is done upstream (in go-github or the GitHub API itself).

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [ ] No

----

